### PR TITLE
Add Authentication and Authorization Audit Report

### DIFF
--- a/AUDIT-AUTH.md
+++ b/AUDIT-AUTH.md
@@ -1,0 +1,33 @@
+# Security Audit: Authentication & Authorization
+
+## Executive Summary
+
+The security audit of authentication and authorization mechanisms for the Poindexter repository has been completed. The investigation concludes that the codebase is a Go library providing data structures and algorithms, specifically k-d trees and sorting utilities. It does not contain any user-facing application, authentication flows, authorization logic, or session management. Therefore, the requested audit categories are not applicable.
+
+## Scope of Review
+
+The audit was initiated to assess the following areas:
+- **Authentication:** Password handling, session management, token security, and multi-factor authentication.
+- **Authorization:** Access control models, permission checks, privilege escalation vulnerabilities, and API protection.
+
+## Findings
+
+A thorough review of the codebase was conducted, including but not limited to the following files:
+- `README.md`
+- `poindexter.go`
+- `kdtree.go`
+- `CLAUDE.md`
+- `npm/poindexter-wasm/smoke.mjs`
+- `wasm/main.go`
+- `go.mod`
+
+The analysis of these files confirms that the repository contains a library and not a service or application. There are no functions or modules related to:
+- User registration or login
+- Password hashing or storage
+- Session or token generation
+- Access control lists (ACLs), role-based access control (RBAC), or other authorization models
+- API endpoints requiring protection
+
+## Conclusion
+
+The Poindexter library, by its nature, does not handle authentication or authorization. As such, there are no vulnerabilities to report in these areas. The audit is concluded as not applicable.


### PR DESCRIPTION
This submission adds the `AUDIT-AUTH.md` file, which is the result of a security audit. The audit found that the codebase is a library and does not have authentication or authorization features, making the audit not applicable. The report details these findings.

Fixes #7

---
*PR created automatically by Jules for task [14394908625938091884](https://jules.google.com/task/14394908625938091884) started by @Snider*