### PR TITLE
Add API Audit Documentation

### DIFF
--- a/AUDIT-API.md
+++ b/AUDIT-API.md
@@ -1,0 +1,52 @@
+# API Audit: Poindexter Go Library
+
+This document audits the public API of the Poindexter Go library, focusing on design, consistency, documentation, and security best practices for a Go library.
+
+## 1. API Design and Consistency
+
+### 1.1. Naming Conventions
+
+*   **Consistency:** The library generally follows Go's naming conventions (`camelCase` for unexported, `PascalCase` for exported).
+*   **Clarity:** Function names are clear and descriptive (e.g., `SortInts`, `SortByKey`, `NewKDTree`).
+*   **Minor Inconsistency:** `IsSorted` exists, but `IsSortedStrings` and `IsSortedFloat64s` are more verbose. A more consistent naming scheme might be `IntsAreSorted`, `StringsAreSorted`, etc., to mirror the standard library's `sort` package.
+
+### 1.2. Generics
+
+*   **Effective Use:** The use of generics in `SortBy` and `SortByKey` is well-implemented and improves type safety and usability.
+*   **`KDPoint`:** The `KDPoint` struct effectively uses generics for its `Value` field, allowing users to associate any data type with a point.
+
+### 1.3. Error Handling
+
+*   **Exported Errors:** The library exports sentinel errors (`ErrEmptyPoints`, `ErrDimMismatch`, etc.), which is a good practice, allowing users to check for specific error conditions.
+*   **Constructor Errors:** The `NewKDTree` constructor correctly returns an error value, forcing callers to handle potential issues during tree creation.
+
+### 1.4. Options Pattern
+
+*   **`NewKDTree`:** The use of the options pattern with `KDOption` functions (`WithMetric`, `WithBackend`) is a great choice. It provides a flexible and extensible way to configure the `KDTree` without requiring a large number of constructor parameters.
+
+## 2. Documentation
+
+*   **Package-Level:** The package-level documentation is good, providing a clear overview of the library's features.
+*   **Exported Symbols:** All exported functions, types, and constants have clear and concise documentation comments.
+*   **Examples:** The `README.md` includes excellent quick-start examples, and the `examples/` directory provides more detailed, runnable examples.
+
+## 3. Security
+
+### 3.1. Input Validation
+
+*   **`NewKDTree`:** The constructor performs thorough validation of its inputs, checking for empty point sets, zero dimensions, and dimensional mismatches. This prevents the creation of invalid `KDTree` instances.
+*   **`KDTree` Methods:** Methods like `Nearest` and `KNearest` validate the dimensionality of the query vector, preventing panics or incorrect behavior.
+*   **`DeleteByID`:** This method correctly handles cases where the ID is not found or is empty.
+
+### 3.2. Panics
+
+*   The public API appears to be free of potential panics. The library consistently uses error returns and input validation to handle exceptional cases.
+
+## Summary and Recommendations
+
+The Poindexter library's public API is well-designed, consistent, and follows Go best practices. The use of generics, the options pattern, and clear error handling make it a robust and user-friendly library.
+
+**Recommendations:**
+
+1.  **Naming Consistency:** Consider renaming `IsSorted`, `IsSortedStrings`, and `IsSortedFloat64s` to `IntsAreSorted`, `StringsAreSorted`, and `Float64sAreSorted` to align more closely with the standard library's `sort` package.
+2.  **Defensive Copying:** The `Points()` method returns a copy of the internal slice, which is excellent. Ensure that any future methods that expose internal state also return copies to prevent mutation by callers.


### PR DESCRIPTION
This change adds a new file, `AUDIT-API.md`, which contains a detailed audit of the public API of the Go library. The audit covers API design, consistency, documentation, and security, and provides recommendations for improvement.

Fixes #16

---
*PR created automatically by Jules for task [11829200880562560951](https://jules.google.com/task/11829200880562560951) started by @Snider*